### PR TITLE
Fix creation of services

### DIFF
--- a/api/v1/keptnservice_types.go
+++ b/api/v1/keptnservice_types.go
@@ -44,6 +44,7 @@ type KeptnServiceStatus struct {
 	SafeToDelete      bool   `json:"safetodelete,omitempty"`
 	Hash              string `json:"hash,omitempty"`
 	DesiredVersion    string `json:"desiredversion,omitempty"`
+	CreationPending   bool   `json:"creationpending,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 }

--- a/controllers/keptnproject_controller.go
+++ b/controllers/keptnproject_controller.go
@@ -19,21 +19,22 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
 	hashdir "github.com/sger/go-hashdir"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"log"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-logr/logr"
@@ -250,6 +251,9 @@ func (r *KeptnProjectReconciler) createKeptnService(project *keptnv1.KeptnProjec
 			Project:        project.Name,
 			Service:        service.Name,
 			TriggerCommand: service.DeploymentTrigger,
+		},
+		Status: keptnv1.KeptnServiceStatus{
+			CreationPending: true,
 		},
 	}
 

--- a/controllers/keptnservice_controller.go
+++ b/controllers/keptnservice_controller.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	nethttp "net/http"
 	"os"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,12 +68,13 @@ func (r *KeptnServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
-	if !r.checkKeptnServiceExists(service, req.Namespace) {
+	if service.Status.CreationPending && !r.checkKeptnServiceExists(service, req.Namespace) {
 		service.Status.LastSetupStatus, err = r.createService(service.Spec.Service, req.Namespace, service.Spec.Project)
 		if err != nil {
 			r.ReqLogger.Error(err, "Could not create service "+service.Spec.Service)
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
+		service.Status.CreationPending = false
 	}
 
 	if service.Status.DeploymentPending {


### PR DESCRIPTION
Only create services that have the status CreationPending set to true, to prevent creation of services that got deleted in keptn but are not synced yet in the project controller. Otherwise it happened that services deleted in keptn got recreated in the service controller.