### PR TITLE
Change api endpoint for checking if keptn service exists

### DIFF
--- a/controllers/keptnservice_controller.go
+++ b/controllers/keptnservice_controller.go
@@ -230,7 +230,11 @@ func (r *KeptnServiceReconciler) checkKeptnServiceExists(service *keptnv1.KeptnS
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "keptn-api-token", Namespace: namespace}, keptnToken)
 	secret := string(keptnToken.Data["keptn-api-token"])
 
-	request, err := nethttp.NewRequest("GET", r.keptnApi+"/configuration-service/v1/project/"+service.Spec.Project+"/stage/"+service.Spec.StartStage+"/service/"+service.Spec.Service+"/resource", bytes.NewBuffer(nil))
+	request, err := nethttp.NewRequest("GET", r.keptnApi+"/controlPlane/v1/project/"+service.Spec.Project+"/stage/"+service.Spec.StartStage+"/service/"+service.Spec.Service+"/resource", bytes.NewBuffer(nil))
+	if err != nil {
+		r.ReqLogger.Error(err, "Could not check if service exists "+service.Spec.Service)
+	}
+
 	request.Header.Set("x-token", secret)
 
 	response, err := httpclient.Do(request)


### PR DESCRIPTION
The problem with the configuration-service endpoint is, that it returns 200 if the git repository contains configuration files for the service, even if it was not created by keptn. Switch to the controlPlane endpoint (wrongly documented in the keptn swagger ui) but works correctly. It returns 200 only if the service has a metadata.yaml configuration in the git repository (fix tested locally)