### PR TITLE
Make the Makefile usable without local kustomize binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ run: generate fmt vet manifests
 
 # Install CRDs into a cluster
 install: manifests
-	kustomize build config/crd | kubectl apply -f -
+	kubectl apply -k config/crd
 
 # Uninstall CRDs from a cluster
 uninstall: manifests
-	kustomize build config/crd | kubectl delete -f -
+	kubectl delete -k config/crd
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests


### PR DESCRIPTION
This commit changes the Makefile to use `kubectl` commands, instead of
relying on having the `kustomize` binary installed. Kustomize comes with
kubectl by default since version 1.14 (`-k` flag).