### PR TITLE
Ensure correct docker org is used

### DIFF
--- a/.ci_env
+++ b/.ci_env
@@ -1,2 +1,2 @@
-DOCKER_ORGANIZATION="keptncontrib"
+DOCKER_ORGANIZATION="keptnsandbox"
 IMAGE="keptn-gitops-operator"


### PR DESCRIPTION
This PR ensures the correct docker org is used.

FYI: We have updated the DOCKER HUB Registry User and Password for keptn-sandbox.