### PR TITLE
Log error when deletion of service fails

### DIFF
--- a/controllers/keptnservice_controller.go
+++ b/controllers/keptnservice_controller.go
@@ -92,10 +92,11 @@ func (r *KeptnServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, nil
 	}
 
-	if service.Status.DeletionPending {
+	if service.Status.DeletionPending && !service.Status.SafeToDelete {
 		r.ReqLogger.Info("Deletion is pending")
 		err = r.deleteService(service.Spec.Service, req.Namespace, service.Spec.Project)
 		if err != nil {
+			r.ReqLogger.Error(err, "Could not delete Service")
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, err
 		}
 		service.Status.SafeToDelete = true


### PR DESCRIPTION
Ran into an issue where the service reconcile loop kept trying to delete a keptn service that was already deleted. Resulted in a lot of failed deletion events in the keptn bridge. The k8s resource finally got deleted after some hours but checking `SafeToDelete` before attempting deletion should prevent this issue. Also more logging if the keptn api response with an error on an deletion attempt.