### PR TITLE
Replaced clusteradmin with specific roles in Helm template

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -11,9 +11,135 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-secrets
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-configmaps
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-services
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - keptn.operator.keptn.sh
+  resources:
+  - keptnservices
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-projects
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - keptn.operator.keptn.sh
+  resources:
+  - keptnprojects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-secrets
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-secrets
+subjects:
+- kind: ServiceAccount
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-configmaps
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-get-configmaps
+subjects:
+- kind: ServiceAccount
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: keptn-{{ .Release.Namespace }}-keptn-gitops-operator-cluster-admin
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-projects
   labels:
     {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -26,5 +152,25 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-projects
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-services
+  labels:
+    {{- include "keptn-gitops-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "keptn-gitops-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "keptn-gitops-operator.serviceAccountName" . }}-manage-services
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Removed the ClusterAdmin from the serviceaccount helm template and created 4 Roles and Rolebindings:
* Local role to get secrets (to access the git creds from keptn) within namespace
* Local role to get configmaps within namespace
* Cluster Role to access keptnprojects
* Cluster Role to access keptnservices